### PR TITLE
Use getBunVersion as Promise

### DIFF
--- a/src/bunHook.ts
+++ b/src/bunHook.ts
@@ -56,10 +56,10 @@ export function installBun(): void {
   terminal.sendText("exit");
   terminal.show();
 
-  window.onDidCloseTerminal((_terminal) => {
+  window.onDidCloseTerminal(async (_terminal) => {
     // Successfully install bun
     if (terminal === _terminal && _terminal.exitStatus?.code === 0) {
-      const version = getBunVersion();
+      const version = await getBunVersion();
       window.showInformationMessage(
         `Successfully install bun with version ${version}`
       );
@@ -98,7 +98,7 @@ export async function installBunAsProcess() {
   await cleanInstallScript(fileDestinationUri);
 
   // Display a message info
-  let bunVersion = getBunVersion();
+  let bunVersion = await getBunVersion();
   window.showInformationMessage(`Successfully install Bun (v${bunVersion})`);
 
   return fileDestinationUri;

--- a/src/bunHook.ts
+++ b/src/bunHook.ts
@@ -109,7 +109,7 @@ export async function installBunAsProcess() {
  * @returns a bun version as semver format
  * @throws when bun is not installed
  */
-export function getBunVersion() {
+export function getBunVersionSync() {
   let bunProcess = spawnSync("bun", ["--version"]);
   if (bunProcess.output === undefined || bunProcess.error !== undefined) {
     throw new Error("Bun is not installed");
@@ -119,6 +119,48 @@ export function getBunVersion() {
     throw new Error("Error with bun output");
   }
   return versionLine.toString().trim();
+}
+
+/**
+ * Spawn a process to get bun version via `bun --version`.
+ *
+ *
+ * @returns a promise that resolve when bun version found,
+ *  or undefined if bun is not installed
+ */
+export function getBunVersion(): Promise<string | undefined> {
+  return new Promise<string | undefined>(async (r, e) => {
+    // If the bun was not installed
+    if (!(await didBunInstalled())) {
+      return undefined;
+    }
+
+    // Get bun directory
+    const bunDirectory = await getBunDirectory();
+    if (!bunDirectory) {
+      return e(new Error("Bun directory not found"));
+    }
+
+    // Spawn bun version to test
+    const bunExecutableFilePath = path.join(bunDirectory, "bin", "bun");
+    const bunVersionProcess = spawn(bunExecutableFilePath, ["--version"]);
+
+    let collector: string = "";
+    bunVersionProcess.stdout.on(
+      "data",
+      (chunk: Buffer) => (collector += chunk)
+    );
+    bunVersionProcess.on("exit", (exitStatus: number) => {
+      if (exitStatus !== 0) {
+        return e(
+          new Error("Process to get version exit with status " + exitStatus)
+        );
+      }
+
+      let version = collector;
+      r(version.trim());
+    });
+  });
 }
 
 export function downloadInstallScript(destination: vscode.Uri): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       // Get bun version
-      const bunVersion = getBunVersion();
+      const bunVersion = await getBunVersion();
       vscode.window.showInformationMessage(
         `The current bun version is ${bunVersion}`
       );
@@ -144,7 +144,7 @@ export function activate(context: vscode.ExtensionContext) {
       // If the bun was install before
       if (await didBunInstalled()) {
         // Get version
-        const bunVersion = getBunVersion();
+        const bunVersion = await getBunVersion();
         return vscode.window.showInformationMessage(
           `Bun was already installed (version ${bunVersion})`
         );

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "child_process";
 import * as open from "open";
 import { platform } from "os";
 import * as vscode from "vscode";

--- a/src/test/suite/bunHook.test.ts
+++ b/src/test/suite/bunHook.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import {
   didBunInstalled,
   getBunVersion,
+  getBunVersionSync,
   installBunAsProcess,
 } from "../../bunHook";
 
@@ -62,6 +63,20 @@ suite("[unit] bunHook - bun is installed", () => {
   mocha.describe("didBunInstall", () => {
     test("should return true when bun installed", async () => {
       expect(await didBunInstalled()).to.be.true;
+    });
+  });
+
+  mocha.describe("getBunVersionSync ", () => {
+    test("should return bun version", () => {
+      expect(getBunVersionSync()).to.be.a.string;
+    });
+  });
+
+  mocha.describe("getBunVersion (async)", () => {
+    test("should return bun version", async () => {
+      expect(await getBunVersion()).to.be.a.string;
+
+      return Promise.resolve();
     });
   });
 });


### PR DESCRIPTION
# Issues
- The `getBunVersion()` now returns a `Promise<string | undefined>` instead of a string (sync method). 
- Add `getBunVersionSync(): string` to replace old getBunVersion()

# Flight-check
- [x] Passed all tests
- [ ]  Document all new functions

Next release at `1.0.0`