### PR TITLE
Add command `Bun: Install dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
       {
         "command": "bunn.installBun",
         "title": "Bun: Install bun (if not exists)"
+      },
+      {
+        "command": "bunn.installDependencies",
+        "title": "Bun: Install dependencies"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,47 +17,52 @@ export function activate(context: vscode.ExtensionContext) {
    */
   context.subscriptions.push(
     vscode.commands.registerCommand("bunn.runFocusFile", async () => {
-      console.log(`Starting to run the bun...`);
+      const runFocusFile = () => {
+        const currentActiveTextEditor = vscode.window.activeTextEditor;
+
+        // If no file was opened
+        if (!currentActiveTextEditor) {
+          vscode.window
+            .showErrorMessage(
+              "Not open any file to run the bun environment.",
+              "Open"
+            )
+            .then((value) => {
+              //  On click open button
+              if (value === "Open") {
+                vscode.window
+                  .showOpenDialog({
+                    canSelectFiles: true,
+                    canSelectFolders: false,
+                    openLabel: "Open file",
+                  })
+                  .then((uris) => {});
+              }
+            });
+          return;
+        }
+
+        const focusingFileName = currentActiveTextEditor.document.fileName;
+
+        // Execute the bun with current file
+        const terminal = vscode.window.createTerminal({
+          name: "Run bun",
+        });
+
+        terminal.sendText(`bun "${focusingFileName}"`);
+        terminal.show();
+      };
 
       // If the bun is not found
       if (!(await didBunInstalled())) {
-        suggestInstallBun();
-        return;
+        return suggestInstallBun()
+          .then(() => {
+            runFocusFile();
+          })
+          .catch((err) => vscode.window.showErrorMessage(err.message));
       }
 
-      const currentActiveTextEditor = vscode.window.activeTextEditor;
-
-      // If no file was opened
-      if (!currentActiveTextEditor) {
-        vscode.window
-          .showErrorMessage(
-            "Not open any file to run the bun environment.",
-            "Open"
-          )
-          .then((value) => {
-            //  On click open button
-            if (value === "Open") {
-              vscode.window
-                .showOpenDialog({
-                  canSelectFiles: true,
-                  canSelectFolders: false,
-                  openLabel: "Open file",
-                })
-                .then((uris) => {});
-            }
-          });
-        return;
-      }
-
-      const focusingFileName = currentActiveTextEditor.document.fileName;
-
-      // Execute the bun with current file
-      const terminal = vscode.window.createTerminal({
-        name: "Run bun",
-      });
-
-      terminal.sendText(`bun "${focusingFileName}"`);
-      terminal.show();
+      runFocusFile();
     })
   );
 
@@ -95,23 +100,29 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("bunn.version", async () => {
       console.log("Running `bun version`...");
 
+      const showVersion = async () => {
+        // Get bun version
+        try {
+          const bunVersion = await getBunVersion();
+          vscode.window.showInformationMessage(
+            `The current bun version is ${bunVersion}`
+          );
+          return;
+        } catch (err: any) {
+          return vscode.window.showErrorMessage(
+            `Error to get bun version ${err.message}`
+          );
+        }
+      };
+
       // If the bun is not found
       if (!(await didBunInstalled())) {
-        suggestInstallBun();
-        return;
+        return suggestInstallBun()
+          .then(async () => await showVersion)
+          .catch((err) => vscode.window.showErrorMessage(err.message));
       }
 
-      // Get bun version
-      try {
-        const bunVersion = await getBunVersion();
-        vscode.window.showInformationMessage(
-          `The current bun version is ${bunVersion}`
-        );
-      } catch (err: any) {
-        return vscode.window.showErrorMessage(
-          `Error to get bun version ${err.message}`
-        );
-      }
+      await showVersion();
     })
   );
 
@@ -121,23 +132,30 @@ export function activate(context: vscode.ExtensionContext) {
    */
   context.subscriptions.push(
     vscode.commands.registerCommand("bunn.runProject", async () => {
+      const runTheProject = async () => {
+        // Determine the project package.json
+        const currentWorkspaceFolders = vscode.workspace.workspaceFolders;
+        if (currentWorkspaceFolders === undefined) {
+          // TODO: turn to open workspace (later)
+          vscode.window.showErrorMessage(`No workspace available.`);
+
+          return;
+        }
+
+        // Display a script selection
+        scriptSelection(currentWorkspaceFolders);
+      };
+
       // If the bun is not found
       if (!(await didBunInstalled())) {
-        suggestInstallBun();
-        return;
+        return suggestInstallBun()
+          .then(async () => {
+            await runTheProject();
+          })
+          .catch((err) => vscode.window.showErrorMessage(err.message));
       }
 
-      // Determine the project package.json
-      const currentWorkspaceFolders = vscode.workspace.workspaceFolders;
-      if (currentWorkspaceFolders === undefined) {
-        // TODO: turn to open workspace (later)
-        vscode.window.showErrorMessage(`No workspace available.`);
-
-        return;
-      }
-
-      // Display a script selection
-      scriptSelection(currentWorkspaceFolders);
+      await runTheProject();
     })
   );
 
@@ -173,7 +191,7 @@ export function activate(context: vscode.ExtensionContext) {
    */
   context.subscriptions.push(
     vscode.commands.registerCommand("bunn.installDependencies", async () => {
-      const installDependency = () => {
+      const installDependency = async () => {
         const terminal = vscode.window.createTerminal({
           name: "Bun: Install dependencies",
         });
@@ -187,12 +205,14 @@ export function activate(context: vscode.ExtensionContext) {
       };
 
       if (!(await didBunInstalled())) {
-        return suggestInstallBun().then(() => {
-          installDependency();
-        });
+        return suggestInstallBun()
+          .then(() => {
+            installDependency();
+          })
+          .catch((err) => vscode.window.showErrorMessage(err.message));
       }
 
-      installDependency();
+      await installDependency();
     })
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,22 +167,32 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  /**
+   * bunn.installDependencies
+   * Install all dependencies
+   */
   context.subscriptions.push(
     vscode.commands.registerCommand("bunn.installDependencies", async () => {
+      const installDependency = () => {
+        const terminal = vscode.window.createTerminal({
+          name: "Bun: Install dependencies",
+        });
+
+        // Add to disposable
+        context.subscriptions.push(terminal);
+
+        // Run bun install
+        terminal.sendText("bun install", true);
+        terminal.show();
+      };
+
       if (!(await didBunInstalled())) {
-        return suggestInstallBun();
+        return suggestInstallBun().then(() => {
+          installDependency();
+        });
       }
 
-      const terminal = vscode.window.createTerminal({
-        name: "Bun: Install dependencies",
-      });
-
-      // Add to disposable
-      context.subscriptions.push(terminal);
-
-      // Run bun install
-      terminal.sendText("bun install", true);
-      terminal.show();
+      installDependency();
     })
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,6 +166,25 @@ export function activate(context: vscode.ExtensionContext) {
       await installBunAsProcess();
     })
   );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("bunn.installDependencies", async () => {
+      if (!(await didBunInstalled())) {
+        return suggestInstallBun();
+      }
+
+      const terminal = vscode.window.createTerminal({
+        name: "Bun: Install dependencies",
+      });
+
+      // Add to disposable
+      context.subscriptions.push(terminal);
+
+      // Run bun install
+      terminal.sendText("bun install", true);
+      terminal.show();
+    })
+  );
 }
 
 // This method is called when your extension is deactivated

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -24,14 +24,18 @@ export function warningWindowsPlatform() {
 }
 
 export function suggestInstallBun() {
-  vscode.window
-    .showInformationMessage(
-      `Bun is not found on your device, click to install or using Bun: Install bun from Command Palette`,
-      `Install`
-    )
-    .then(async (value) => {
-      if (value === "Install") {
-        await installBunAsProcess();
-      }
-    });
+  return new Promise<void>((resolve, reject) => {
+    vscode.window
+      .showInformationMessage(
+        `Bun is not found on your device, click to install or using Bun: Install bun from Command Palette`,
+        `Install`
+      )
+      .then(async (value) => {
+        if (value === "Install") {
+          await installBunAsProcess()
+            .then(() => resolve())
+            .catch(reject);
+        }
+      });
+  });
 }


### PR DESCRIPTION
# Descibes
In order to install all dependencies in the current Folder (Workspace) that users are opening from the `package.json` file. 

The command actually executes the command `bun install` inside the integrated terminal. 

# Flight-check
- [x] Add tests
- [x] All tests passed
- [x] Document 